### PR TITLE
Added support for images with external source.

### DIFF
--- a/Source/model/scene/Group.swift
+++ b/Source/model/scene/Group.swift
@@ -19,7 +19,22 @@ open class Group: Node {
       }
     }
   }
-  
+
+  open var imagesWithExternalSource: [Image] {
+    var images = [Image]()
+
+    contents.forEach {
+        switch $0 {
+        case let image as Image where image.isSourceExternal:
+            images.append(image)
+        case let group as Group:
+            images += group.imagesWithExternalSource
+        default:
+            break
+        }
+    }
+    return images
+  }
   
   public init(contents: [Node] = [], place: Transform = Transform.identity, opaque: Bool = true, opacity: Double = 1, clip: Locus? = nil, effect: Effect? = nil, visible: Bool = true, tag: [String] = []) {
     self.contentsVar = AnimatableVariable<[Node]>(contents)

--- a/Source/model/scene/Image.swift
+++ b/Source/model/scene/Image.swift
@@ -116,7 +116,7 @@ open class Image: Node {
     
   }
 
-  func setImage(_ image: MImage?) {
+  public func setImage(_ image: MImage?) {
     mImage = image
     // Notify consumers that we now have an image for our source.    
     srcVar.value = src

--- a/Source/model/scene/Image.swift
+++ b/Source/model/scene/Image.swift
@@ -41,6 +41,14 @@ open class Image: Node {
     get { return hVar.value }
     set(val) { hVar.value = val }
   }
+
+  /**
+     Whether the underlying image source is external and will require
+     to be explicitly set through the setImage(_) method.
+  */
+  open var isSourceExternal: Bool {
+    get { return src.hasPrefix("http://") || src.hasPrefix("https://") }
+  }
   
   private var mImage: MImage?
   
@@ -107,6 +115,12 @@ open class Image: Node {
                 h: Double(mImage.size.height))
     
   }
+
+  func setImage(_ image: MImage?) {
+    mImage = image
+    // Notify consumers that we now have an image for our source.    
+    srcVar.value = src
+  }
   
   func image() -> MImage? {
     
@@ -129,6 +143,10 @@ open class Image: Node {
       }
       
       return MImage(data: decodedData)
+    }
+
+    if isSourceExternal {
+        return nil
     }
     
     // General case

--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -12,7 +12,7 @@ open class SVGParser {
     
     /// Parse an SVG file identified by the specified bundle, name and file extension.
     /// - returns: Root node of the corresponding Macaw scene.
-    open class func parse(bundle: Bundle, path: String, ofType: String = "svg") throws -> Node {
+    open class func parse(bundle: Bundle, path: String, ofType: String = "svg") throws -> Group {
         guard let fullPath = bundle.path(forResource: path, ofType: ofType) else {
             throw SVGParserError.noSuchFile(path: "\(path).\(ofType)")
         }
@@ -22,13 +22,13 @@ open class SVGParser {
     
     /// Parse an SVG file identified by the specified name and file extension.
     /// - returns: Root node of the corresponding Macaw scene.
-    open class func parse(path: String, ofType: String = "svg") throws -> Node {
+    open class func parse(path: String, ofType: String = "svg") throws -> Group {
         return try SVGParser.parse(bundle: Bundle.main, path: path, ofType: ofType)
     }
     
     /// Parse the specified content of an SVG file.
     /// - returns: Root node of the corresponding Macaw scene.
-    open class func parse(text: String) throws -> Node {
+    open class func parse(text: String) throws -> Group {
         return SVGParser(text).parse()
     }
     


### PR DESCRIPTION
Images in SVG can reference remote images that needs to be downloaded. I don't think downloading images should be part of that project, so I exposed a way for consumers to know about image nodes that reference external sources. Consumers can then download the sources and inject them using the setImage function.