### PR TITLE
Basic support for SVG viewBox.

### DIFF
--- a/Macaw.xcodeproj/project.pbxproj
+++ b/Macaw.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		A718CD501F45C28F00966E06 /* MView_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A718CD4C1F45C28F00966E06 /* MView_macOS.swift */; };
 		A718CD521F45C2A400966E06 /* MBezierPath+Extension_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A718CD511F45C2A400966E06 /* MBezierPath+Extension_macOS.swift */; };
 		A7E675561EC4213500BD9ECB /* NodeBoundsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E675551EC4213500BD9ECB /* NodeBoundsTests.swift */; };
+		DC605D3F1F6064BE0081DDF8 /* Node+CGContextRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC605D3E1F6064BE0081DDF8 /* Node+CGContextRender.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -309,6 +310,7 @@
 		A718CD4C1F45C28F00966E06 /* MView_macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MView_macOS.swift; path = Source/platform/macOS/MView_macOS.swift; sourceTree = SOURCE_ROOT; };
 		A718CD511F45C2A400966E06 /* MBezierPath+Extension_macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MBezierPath+Extension_macOS.swift"; path = "Source/platform/macOS/MBezierPath+Extension_macOS.swift"; sourceTree = SOURCE_ROOT; };
 		A7E675551EC4213500BD9ECB /* NodeBoundsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NodeBoundsTests.swift; path = Bounds/NodeBoundsTests.swift; sourceTree = "<group>"; };
+		DC605D3E1F6064BE0081DDF8 /* Node+CGContextRender.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Node+CGContextRender.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -363,6 +365,7 @@
 			isa = PBXGroup;
 			children = (
 				57900FF81EA0DEBF00809FFB /* UIImage2Image.swift */,
+				DC605D3E1F6064BE0081DDF8 /* Node+CGContextRender.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -945,6 +948,7 @@
 				57E5E16B1E3B393900D1CB28 /* AnimationSequence.swift in Sources */,
 				57E5E1671E3B393900D1CB28 /* MorphingGenerator.swift in Sources */,
 				57E5E1AA1E3B393900D1CB28 /* SVGConstants.swift in Sources */,
+				DC605D3F1F6064BE0081DDF8 /* Node+CGContextRender.swift in Sources */,
 				57E5E1B41E3B393900D1CB28 /* ShapeLayer.swift in Sources */,
 				57E5E15E1E3B393900D1CB28 /* LocusInterpolation.swift in Sources */,
 			);

--- a/Source/model/scene/Group.swift
+++ b/Source/model/scene/Group.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 open class Group: Node {
-  
+
+  open var viewBoxVar = Variable<Rect?>(nil)
+  open var viewBox: Rect? {
+    get { return viewBoxVar.value }
+    set { viewBoxVar.value = newValue }
+  }
+
   open var contentsVar: AnimatableVariable<[Node]>
   open var contents: [Node] {
     get { return contentsVar.value }

--- a/Source/model/scene/Group.swift
+++ b/Source/model/scene/Group.swift
@@ -73,6 +73,10 @@ open class Group: Node {
   
   // GENERATED NOT
   override internal func bounds() -> Rect? {
+    if let viewBox = viewBox {
+        return viewBox
+    }
+
     var union: Rect?
     
     contents.forEach { node in

--- a/Source/render/GroupRenderer.swift
+++ b/Source/render/GroupRenderer.swift
@@ -34,7 +34,24 @@ class GroupRenderer: NodeRenderer {
   override func node() -> Node? {
     return group
   }
-  
+
+  override func renderTransform() -> CGAffineTransform {
+    var transform = CGAffineTransform.identity
+    if let renderRect = ctx.renderRect, let viewBox = group?.viewBox {
+        transform = transform.translatedBy(x: renderRect.origin.x, y: renderRect.origin.y)
+
+        let wRatio = renderRect.width / CGFloat(viewBox.w)
+        let hRatio = renderRect.height / CGFloat(viewBox.h)
+        transform = transform
+            .scaledBy(x: wRatio, y: hRatio)
+            .translatedBy(x: CGFloat(-viewBox.x), y: CGFloat(-viewBox.y))
+    }
+
+    transform = transform.concatenating(super.renderTransform())
+
+    return transform
+  }
+
   override func doRender(_ force: Bool, opacity: Double) {
     renderers.forEach { renderer in
       renderer.render(force: force, opacity: opacity)

--- a/Source/render/NodeRenderer.swift
+++ b/Source/render/NodeRenderer.swift
@@ -69,6 +69,10 @@ class NodeRenderer {
     open func node() -> Node? {
         fatalError("Unsupported")
     }
+
+    func renderTransform() -> CGAffineTransform {
+        return node().map { RenderUtils.mapTransform($0.place) } ?? CGAffineTransform.identity
+    }
     
     final public func render(force: Bool, opacity: Double) {
         ctx.cgContext!.saveGState()
@@ -79,8 +83,10 @@ class NodeRenderer {
         guard let node = node() else {
             return
         }
+
+        let transform = renderTransform()
         
-        ctx.cgContext!.concatenate(RenderUtils.mapTransform(node.place))
+        ctx.cgContext!.concatenate(transform)
         applyClip()
         directRender(force: force, opacity: node.opacity * opacity)
     }

--- a/Source/render/RenderContext.swift
+++ b/Source/render/RenderContext.swift
@@ -7,6 +7,7 @@ import Foundation
 class RenderContext {
   weak var view: MView?
   weak var cgContext: CGContext?
+  var renderRect: CGRect?
   
   init(view: MView?) {
     self.view = view

--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -45,7 +45,8 @@ open class SVGParser {
     fileprivate var defNodes = [String: Node]()
     fileprivate var defFills = [String: Fill]()
     fileprivate var defMasks = [String: Shape]()
-    
+    private var viewBox: Rect?
+
     fileprivate enum PathCommandType {
         case moveTo
         case lineTo
@@ -69,6 +70,7 @@ open class SVGParser {
         iterateThroughXmlTree(parsedXml.children)
         
         let group = Group(contents: self.nodes, place: initialPosition)
+        group.viewBox = viewBox
         return group
     }
     
@@ -76,6 +78,14 @@ open class SVGParser {
         children.forEach { child in
             if let element = child.element {
                 if element.name == "svg" {
+                    if let viewBoxValue: String = element.value(ofAttribute: "viewBox") {
+                        let rectValues = viewBoxValue.components(separatedBy: CharacterSet.whitespaces).flatMap { Double($0) }
+                        if rectValues.count == 4 {
+                            self.viewBox = Rect(x: rectValues[0], y: rectValues[1], w: rectValues[2], h: rectValues[3])
+                        } else {
+                            print("SVG parsing error: Invalid viewBox \(viewBoxValue)")
+                        }
+                    }
                     iterateThroughXmlTree(child.children)
                 } else if let node = parseNode(child) {
                     self.nodes.append(node)

--- a/Source/utils/Node+CGContextRender.swift
+++ b/Source/utils/Node+CGContextRender.swift
@@ -7,9 +7,16 @@
 //
 
 import Foundation
+import CoreGraphics
 
 public extension Node {
 
+    /**
+     Draw the receiver Node in the given rect and CGContext.
+     You can use that if you don't want to use MacawView
+     or want a way to directly render a Node into a CGBitmapContext
+     for instance.
+     */
     public func draw(in rect: CGRect, context: CGContext, opacity: Double = 1) {
         let renderContext = RenderContext(view: nil)
         renderContext.cgContext = context

--- a/Source/utils/Node+CGContextRender.swift
+++ b/Source/utils/Node+CGContextRender.swift
@@ -1,0 +1,23 @@
+//
+//  NodeToUIImage.swift
+//  Macaw
+//
+//  Created by Simon Corsin on 9/6/17.
+//  Copyright © 2017 Exyte. All rights reserved.
+//
+
+import Foundation
+
+public extension Node {
+
+    public func draw(in rect: CGRect, context: CGContext, opacity: Double = 1) {
+        let renderContext = RenderContext(view: nil)
+        renderContext.cgContext = context
+        renderContext.renderRect = rect
+
+        let renderer = RenderUtils.createNodeRenderer(self, context: renderContext, animationCache: nil)
+        defer { renderer.dispose() }
+        renderer.render(force: true, opacity: opacity)
+    }
+
+}

--- a/Source/views/MacawView.swift
+++ b/Source/views/MacawView.swift
@@ -166,6 +166,8 @@ open class MacawView: MView, MGestureRecognizerDelegate {
     defer {
       prevAnimatedNodes = animatedNodes
     }
+
+    context.renderRect = bounds
     
     // No animation case
     if animatedNodes.count == 0 || animatedNodes.count > 20 {


### PR DESCRIPTION
ViewBox allows to define a canvas with static coordinates that can then be stretched based on the actual render rect. The current implementation works in my use case but might not respect 100% the specs, I'm unsure about how the x,y should be treated when we need to stretch.

Some explanation here: https://www.sarasoueidan.com/blog/svg-coordinate-systems/

Also added a way to render a Node directly into a CGContext without going through CALayer's or UIView's. In my use case I don't need the touch support and would rather have the rendering be done in a light way manner in a background thread without having to create a UIView's hierarchy.