### PR TITLE
Added functionality for loading SVGs from device disk

### DIFF
--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -31,7 +31,16 @@ open class SVGParser {
     open class func parse(text: String) throws -> Node {
         return SVGParser(text).parse()
     }
-
+    
+    
+    /// Parse the specified content of an SVG file on device (not part of the bundle
+    /// - returns: Root node of the corresponding Macaw scene.
+    open class func parse(file: URL) throws -> Node {
+        guard let text = try? String(contentsOfFile: file.path, encoding: String.Encoding.utf8) else {
+            throw SVGParserError.noSuchFile(path: "\(file.absoluteString)")
+        }
+        return try SVGParser.parse(text: text)
+    }
     let availableStyleAttributes = ["stroke", "stroke-width", "stroke-opacity", "stroke-dasharray", "stroke-linecap", "stroke-linejoin",
                                     "fill", "text-anchor", "clip-path", "fill-opacity",
                                     "stop-color", "stop-opacity",

--- a/Source/svg/SVGView.swift
+++ b/Source/svg/SVGView.swift
@@ -17,6 +17,13 @@ open class SVGView: MacawView {
             render()
         }
     }
+    
+    open var deviceFileName: URL? {
+        didSet {
+            parseFromLocalFile(file: deviceFileName)
+            render()
+        }
+    }
 
     public init(node: Node = Group(), frame: CGRect) {
         super.init(frame: frame)
@@ -46,6 +53,12 @@ open class SVGView: MacawView {
 
     fileprivate func parseSVG() {
         svgNode = try? SVGParser.parse(path: fileName ?? "")
+    }
+    
+    fileprivate func parseFromLocalFile(file: URL?) {
+        if let file = file {
+            svgNode = try? SVGParser.parse(file: file)
+        }
     }
 
     fileprivate func render() {


### PR DESCRIPTION
Messing with an editor tool for personal usage and wanted to be able to load file into an SVGView.  Hopefully it is truly not possible and I didn't miss anything.

Some maybe future considerations...

```
    @IBInspectable open var fileName: String? {
        didSet {
            parseSVG()
            render()
        }
    }
    
    open var deviceFileName: URL? {
        didSet {
            parseFromLocalFile(file: deviceFileName)
            render()
        }
    }
```

I was tempted to switch the fileName prop to bundleAsset or something like that, since semantically it seemed more accurate.  I didn't want to make a breaking change though in hopes to get this PR accepted.