### PR TITLE
Avoiding crash on multi-touch

### DIFF
--- a/Source/animation/types/animation_generators/ShapeAnimationGenerator.swift
+++ b/Source/animation/types/animation_generators/ShapeAnimationGenerator.swift
@@ -14,22 +14,12 @@ import UIKit
 import AppKit
 #endif
 
-class NodeHolder {
-    static var node: Shape?
-}
-
 func addShapeAnimation(_ animation: BasicAnimation, sceneLayer: CALayer, animationCache: AnimationCache?, completion: @escaping (() -> Void)) {
     guard let shapeAnimation = animation as? ShapeAnimation else {
         return
     }
 
-    guard let nodeId = animation.nodeId else {
-        return
-    }
-    if NodeHolder.node == nil {
-        NodeHolder.node = Node.nodeBy(id: nodeId) as? Shape
-    }
-    guard let shape = NodeHolder.node else {
+    guard let nodeId = animation.nodeId, let shape = Node.nodeBy(id: nodeId) as? Shape else {
         return
     }
 

--- a/Source/animation/types/animation_generators/ShapeAnimationGenerator.swift
+++ b/Source/animation/types/animation_generators/ShapeAnimationGenerator.swift
@@ -23,13 +23,13 @@ func addShapeAnimation(_ animation: BasicAnimation, sceneLayer: CALayer, animati
         return
     }
 
-    let mutatingShape = SceneUtils.shapeCopy(from: shape)
-    nodesMap.replace(node: shape, to: mutatingShape)
-    animationCache?.replace(original: shape, replacement: mutatingShape)
-
     let fromShape = shapeAnimation.getVFunc()(0.0)
     let toShape = shapeAnimation.getVFunc()(animation.autoreverses ? 0.5 : 1.0)
     let duration = animation.autoreverses ? animation.getDuration() / 2.0 : animation.getDuration()
+
+    let mutatingShape = SceneUtils.shapeCopy(from: fromShape)
+    nodesMap.replace(node: shape, to: mutatingShape)
+    animationCache?.replace(original: shape, replacement: mutatingShape)
 
     guard let layer = animationCache?.layerForNode(mutatingShape, animation: animation, shouldRenderContent: false) else {
         return

--- a/Source/views/MacawView.swift
+++ b/Source/views/MacawView.swift
@@ -296,7 +296,9 @@ open class MacawView: MView, MGestureRecognizerDelegate {
 
             var points = [TouchPoint]()
             for initialTouch in initialTouches {
-                let currentIndex = touches.index(of: initialTouch)!
+                guard let currentIndex = touches.index(of: initialTouch) else {
+                    continue
+                }
                 let currentTouch = touches[currentIndex]
                 let location = CGPoint(x: currentTouch.x, y: currentTouch.y)
                 let inverted = currentNode.place.invert()!


### PR DESCRIPTION
This change avoids force unwrapping of something that might not exist.  You can witness the crash that this could cause by running the Macaw Example project and going to the Events demo.  Then use more than one finger and watch the thread exception on line 299 of MacawView.swift.

This may not be the best long term way to deal with multi-touch, but it is definitely an improvement.