### PR TITLE
support opacity in svg element

### DIFF
--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -1235,7 +1235,10 @@ open class SVGParser {
             if xScale == yScale {
                 r *= xScale
             } else {
+                #if DEBUG
                 print("SVG parsing error. No oval radial gradients supported")
+                #endif
+                r *= (xScale + yScale) / 2
             }
 
             let point2 = CGPoint(x: fx, y: fy).applying(cgTransform)

--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -118,23 +118,32 @@ open class SVGParser {
             config.shouldProcessNamespaces = true
         }
         let parsedXml = config.parse(xmlString)
-
-        var layout: NodeLayout?
+        
+        var svgElement: XMLElement!
         for child in parsedXml.children {
             if let element = child.element {
                 if element.name == "svg" {
-                    layout = try parseViewBox(element)
+                    svgElement = element
                     try prepareSvg(child.children)
                     break
                 }
             }
         }
         try parseSvg(parsedXml.children)
-
-        if let layout = layout {
-            return SVGCanvas(layout: layout, contents: nodes)
+        
+        var group: Group
+        if let layout = try parseViewBox(svgElement!) {
+            group = SVGCanvas(layout: layout, contents: nodes)
+        } else {
+            group = Group(contents: nodes)
         }
-        return Group(contents: nodes)
+        
+        // global opacity
+        if let opacity = svgElement.attribute(by: "opacity") {
+            group.opacity = Double(opacity.text)!
+        }
+        
+        return group
     }
 
     fileprivate func prepareSvg(_ children: [XMLIndexer]) throws {
@@ -229,7 +238,7 @@ open class SVGParser {
         var result: Node?
         if let element = node.element {
             let style = getStyleAttributes(groupStyle, element: element)
-            if style["display"] == "none" {
+            if style["display"] == "none" || style["visibility"] == "hidden" {
                 return .none
             }
             switch element.name {


### PR DESCRIPTION
1. support opacity at svg level as global opacity
2. a minor modification to avoid useless parsing when visibility is none