### PR TITLE
Add swift version to podspec

### DIFF
--- a/Macaw.podspec
+++ b/Macaw.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.12"
   s.requires_arc = true
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
+  s.swift_version = "4.2"
 
   s.source_files = [
      'Source/**/*.swift'


### PR DESCRIPTION
Define swift_version for the Podfile which is read when the library is
integrated

If this is not supplied then Macaw in Pods settings of the integrated
project gets the project's swift version which leads to a problem
if the integrator is using different Swift version in his project

For him the only workaround is to specify the post_install hook
where he sets the config.build_settings['SWIFT_VERSION'] = '4.2'

https://github.com/CocoaPods/CocoaPods/issues/7327

For library developers who rely on this library this is also the problem
because the s.pod_target_xcconfig is ignored when using the cocoapods-packager

https://github.com/CocoaPods/cocoapods-packager/issues/210