### PR TITLE
Add missing Carthage support

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "drmohundro/SWXMLHash" ~> 4.7.5

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "drmohundro/SWXMLHash" "4.7.6"


### PR DESCRIPTION
For some reason the Cartfile was missing so when adding this library using Carthage the SWXMLhash dependency did not get downloaded