### PR TITLE
#640 Remove force unwrap in `SVGParser.doubleFromString` method

### DIFF
--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -1675,7 +1675,7 @@ open class SVGParser {
 
             let unitString = (string as NSString).substring(with: match.range(at: 1))
             let numberString = String(string.dropLast(unitString.count))
-            let value = Double(numberString)!
+            let value = Double(numberString) ?? 0
             switch unitString {
             case "px" :
                 return value


### PR DESCRIPTION
There are two other possible fixes:
1. Add "null" string to this check in the beginning of `SVGParser.doubleFromString` method
```
if string == "none" {
   return 0
}
```
2. Make `SVGParserRegexHelper.unitsIdenitifierPattern` regexp stricter

However, I decided to go with the least destructive fix because tbh I don't know enough about SVG standard.