### PR TITLE
Fix polyline and polygon points parsing

### DIFF
--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -986,15 +986,14 @@ open class SVGParser {
 
     fileprivate func parsePoints(_ pointsString: String) -> [Double] {
         var resultPoints: [Double] = []
-        let pointPairs = pointsString.replacingOccurrences(of: "-", with: " -").components(separatedBy: " ")
 
-        pointPairs.forEach { pointPair in
-            let points = pointPair.components(separatedBy: ",")
-            points.forEach { point in
-                if let resultPoint = Double(point) {
-                    resultPoints.append(resultPoint)
-                }
+        let scanner = Scanner(string: pointsString)
+        while !scanner.isAtEnd {
+            var resultPoint: Double = 0
+            if scanner.scanDouble(&resultPoint) {
+                resultPoints.append(resultPoint)
             }
+            _ = scanner.scanCharacters(from: [","], into: nil)
         }
 
         if resultPoints.count % 2 == 1 {


### PR DESCRIPTION
Handling of numbers in scientific notation in `parsePoints` used to be
incorrect, because a number could be broken by an exponent minus sign,
resulting in incorrect values.

E.g. '2.5e-1' -> '2.5e', '-1'.

String-splitting-based parsing is replaced with a simpler use of `Scanner`, otherwise keeping the behaviour, esp. error handling, unchanged.