### PR TITLE
Fix typecheck

### DIFF
--- a/Source/model/draw/ColorMatrix.swift
+++ b/Source/model/draw/ColorMatrix.swift
@@ -57,7 +57,7 @@ open class ColorMatrix {
         let m3 = [-0.213, -0.715, 0.928,
                   0.143, 0.140, -0.283,
                   -0.787, 0.715, 0.072]
-        let a = { i in
+        let a = { (i: Int) -> Double in
             m1[i] + c * m2[i] + s * m3[i]
         }
         self.init(values: [a(0), a(1), a(2), 0, 0,


### PR DESCRIPTION
For some reason compiler may fail on this part with
`The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions.`
![Xnip2020-06-26_15-00-55](https://user-images.githubusercontent.com/42281892/85855279-aea5eb80-b7be-11ea-8899-0b25a46c051f.jpg)
