### PR TITLE
Fixed `onTap(..)` handler - unable to add second tap handler

### DIFF
--- a/Source/model/scene/Node.swift
+++ b/Source/model/scene/Node.swift
@@ -111,11 +111,11 @@ open class Node: Drawable {
 
     @discardableResult public func onTap(tapCount: Int = 1, f: @escaping (TapEvent) -> Void) -> Disposable {
         let handler = ChangeHandler<TapEvent>(f)
-        if var handlers = tapHandlers[tapCount] {
-            handlers.append(handler)
-        } else {
-            tapHandlers[tapCount] = [handler]
-        }
+        
+        var handlers = tapHandlers[tapCount] ?? []
+        handlers.append(handler)
+        
+        tapHandlers[tapCount] = handlers
 
         return Disposable { [weak self, unowned handler]  in
             guard let index = self?.tapHandlers[tapCount]?.firstIndex(of: handler) else {


### PR DESCRIPTION
### Updates
In this pull request I'm going to fix the logic of registering new tap handlers.

Previous implementation of this method is completely wrong, because `copy-on-write` behaviour was not considered.

New handler was appended to copy in this line - `handlers.append(handler)`. `tapHandlers` dictionary was not changes, so as a user:
- I was not able to register second tap handler for the same node
- I was not able to register new tap handler if I disposed previous one

This is old implementation:
```swift
    @discardableResult public func onTap(tapCount: Int = 1, f: @escaping (TapEvent) -> Void) -> Disposable {
        let handler = ChangeHandler<TapEvent>(f)
        if var handlers = tapHandlers[tapCount] { // array copy is created
            handlers.append(handler) // copy is mutated here, so changes not applied to `self.tapHandlers`
        } else {
            tapHandlers[tapCount] = [handler]
        }

        return Disposable { [weak self, unowned handler]  in
            guard let index = self?.tapHandlers[tapCount]?.firstIndex(of: handler) else {
                return
            }

            self?.tapHandlers[tapCount]?.remove(at: index)
        }
    }
```

Issue is fixed in new implementation.