### PR TITLE
Fixed retain cycles between MacawView and MacawZoom

### DIFF
--- a/Source/views/MacawView.swift
+++ b/Source/views/MacawView.swift
@@ -15,7 +15,7 @@ open class MacawView: MView, MGestureRecognizerDelegate {
 
     internal var drawingView = DrawingView()
 
-    public let zoom = MacawZoom()
+    public lazy var zoom = MacawZoom(view: self)
 
     open var node: Node {
         get { return drawingView.node }
@@ -77,7 +77,7 @@ open class MacawView: MView, MGestureRecognizerDelegate {
         self.node = node
         self.renderer = RenderUtils.createNodeRenderer(node, view: drawingView)
 
-        zoom.initialize(view: self, onChange: onZoomChange)
+        zoom.initialize(onChange: onZoomChange)
         initializeView()
     }
 
@@ -91,7 +91,7 @@ open class MacawView: MView, MGestureRecognizerDelegate {
     public override init(frame: CGRect) {
         super.init(frame: frame)
 
-        zoom.initialize(view: self, onChange: onZoomChange)
+        zoom.initialize(onChange: onZoomChange)
         initializeView()
     }
 

--- a/Source/views/MacawView.swift
+++ b/Source/views/MacawView.swift
@@ -77,7 +77,9 @@ open class MacawView: MView, MGestureRecognizerDelegate {
         self.node = node
         self.renderer = RenderUtils.createNodeRenderer(node, view: drawingView)
 
-        zoom.initialize(onChange: onZoomChange)
+        zoom.initialize(onChange: { [weak self] transform in
+            self?.onZoomChange(t: transform)
+        })
         initializeView()
     }
 
@@ -91,7 +93,9 @@ open class MacawView: MView, MGestureRecognizerDelegate {
     public override init(frame: CGRect) {
         super.init(frame: frame)
 
-        zoom.initialize(onChange: onZoomChange)
+        zoom.initialize(onChange: { [weak self] transform in
+            self?.onZoomChange(t: transform)
+        })
         initializeView()
     }
 

--- a/Source/views/MacawZoom.swift
+++ b/Source/views/MacawZoom.swift
@@ -16,14 +16,18 @@ import AppKit
 
 open class MacawZoom {
 
-    private var view: MacawView!
-    private var onChange: ((Transform) -> Void)!
+    private unowned let view: MacawView
+    private var onChange: ((Transform) -> Void)?
     private var touches = [TouchData]()
     private var zoomData = ZoomData()
 
     private var trackMove = false
     private var trackScale = false
     private var trackRotate = false
+    
+    init(view: MacawView) {
+        self.view = view
+    }
 
     open func enable(move: Bool = true, scale: Bool = true, rotate: Bool = false) {
         trackMove = move
@@ -47,11 +51,10 @@ open class MacawZoom {
         let s = scale ?? zoomData.scale
         let a = angle ?? zoomData.angle
         zoomData = ZoomData(offset: o, scale: s, angle: a)
-        onChange(zoomData.transform())
+        onChange?(zoomData.transform())
     }
 
-    func initialize(view: MacawView, onChange: @escaping ((Transform) -> Void)) {
-        self.view = view
+    func initialize(onChange: @escaping (Transform) -> Void) {
         self.onChange = onChange
     }
 
@@ -63,7 +66,7 @@ open class MacawZoom {
 
     func touchesMoved(_ touches: Set<MTouch>) {
         let zoom = cleanTouches() ?? getNewZoom()
-        onChange(zoom.transform())
+        onChange?(zoom.transform())
     }
 
     func touchesEnded(_ touches: Set<MTouch>) {


### PR DESCRIPTION
### Updates
In this pull request I fixed 2 issues:
- retain cycle between `MacawView and MacawZoom`: both classes referenced to each other using strong reference which produced retain cycle previously.
Solution is easy - just to use some weak / unowned reference.

- implicit retain cycle with `onZoomChange` method. As we know - `self` is also implicitly captured when we pass `method` as `closure`.
So instead of directly passing method name as closure - `zoom.initialize(view: self, onChange: onZoomChange)` we have to wrap it into additional closure with [weak self] parameter in capture list:

```swift
zoom.initialize(onChange: { [weak self] transform in
    self?.onZoomChange(t: transform)
})
```