### PR TITLE
Fixed retain cycle between GroupRenderer and `parentRenderer`

### DIFF
--- a/Source/render/NodeRenderer.swift
+++ b/Source/render/NodeRenderer.swift
@@ -29,8 +29,8 @@ class NodeRenderer {
     var layer: CachedLayer?
     var zPosition: Int = 0
 
-    let parentRenderer: GroupRenderer?
-
+    private(set) weak var parentRenderer: GroupRenderer?
+    
     fileprivate let onNodeChange: () -> Void
     fileprivate let disposables = GroupDisposable()
     fileprivate var active = false


### PR DESCRIPTION
### Updates
In this pull request I fixed retain cycle between `GroupRenderer` and `NodeRenderer`:
- `parentRenderer` should not be strong, because `GroupRenderer` also strongly referencing to his child renderers.

I saw that you are trying to broke the retain cycle in `dispose()` method inside `deinit`, but `deinit` won't be called while this retain cycle exists and I didn't see any other place where `dispose()` method could be called from outside.