### PR TITLE
Added node search by predicate

### DIFF
--- a/Source/model/scene/Group.swift
+++ b/Source/model/scene/Group.swift
@@ -26,28 +26,28 @@ open class Group: Node {
     }
 
     // Searching
-
-    override public func nodeBy(tag: String) -> Node? {
-        if let node = super.nodeBy(tag: tag) {
+    
+    override public func nodeBy(predicate: (String) -> Bool) -> Node? {
+        if let node = super.nodeBy(predicate: predicate) {
             return node
         }
 
         for child in contents {
-            if let node = child.nodeBy(tag: tag) {
+            if let node = child.nodeBy(predicate: predicate) {
                 return node
             }
         }
 
         return .none
     }
-
-    override public func nodesBy(tag: String) -> [Node] {
+    
+    override public func nodesBy(predicate: (String) -> Bool) -> [Node] {
         var result = [Node]()
         contents.forEach { child in
-            result.append(contentsOf: child.nodesBy(tag: tag))
+            result.append(contentsOf: child.nodesBy(predicate: predicate))
         }
 
-        if let node = super.nodeBy(tag: tag) {
+        if let node = super.nodeBy(predicate: predicate) {
             result.append(node)
         }
 

--- a/Source/model/scene/Group.swift
+++ b/Source/model/scene/Group.swift
@@ -27,7 +27,7 @@ open class Group: Node {
 
     // Searching
     
-    override public func nodeBy(predicate: (String) -> Bool) -> Node? {
+    override public func nodeBy(predicate: (Node) -> Bool) -> Node? {
         if let node = super.nodeBy(predicate: predicate) {
             return node
         }
@@ -41,7 +41,7 @@ open class Group: Node {
         return .none
     }
     
-    override public func nodesBy(predicate: (String) -> Bool) -> [Node] {
+    override public func nodesBy(predicate: (Node) -> Bool) -> [Node] {
         var result = [Node]()
         contents.forEach { child in
             result.append(contentsOf: child.nodesBy(predicate: predicate))

--- a/Source/model/scene/Node.swift
+++ b/Source/model/scene/Node.swift
@@ -42,16 +42,24 @@ open class Node: Drawable {
 
     // MARK: - Searching
     public func nodeBy(tag: String) -> Node? {
-        if self.tag.contains(tag) {
-            return self
-        }
-
-        return .none
+        return nodeBy(predicate: { $0 == tag })
     }
 
     public func nodesBy(tag: String) -> [Node] {
-        return [nodeBy(tag: tag)].compactMap { $0 }
+        return nodesBy(predicate: { $0 == tag })
     }
+    
+    public func nodeBy(predicate: (String) -> Bool) -> Node? {
+        if self.tag.contains(where: predicate) {
+            return self
+        }
+        return .none
+    }
+    
+    public func nodesBy(predicate: (String) -> Bool) -> [Node] {
+        return [nodeBy(predicate: predicate)].compactMap { $0 }
+    }
+
 
     // MARK: - Events
     internal var animationObservers = [AnimationObserver]()

--- a/Source/model/scene/Node.swift
+++ b/Source/model/scene/Node.swift
@@ -42,21 +42,21 @@ open class Node: Drawable {
 
     // MARK: - Searching
     public func nodeBy(tag: String) -> Node? {
-        return nodeBy(predicate: { $0 == tag })
+        return nodeBy(predicate: { $0.tag.contains(tag) })
     }
 
     public func nodesBy(tag: String) -> [Node] {
-        return nodesBy(predicate: { $0 == tag })
+        return nodesBy(predicate: { $0.tag.contains(tag) })
     }
     
-    public func nodeBy(predicate: (String) -> Bool) -> Node? {
-        if self.tag.contains(where: predicate) {
+    public func nodeBy(predicate: (Node) -> Bool) -> Node? {
+        if predicate(self) {
             return self
         }
         return .none
     }
     
-    public func nodesBy(predicate: (String) -> Bool) -> [Node] {
+    public func nodesBy(predicate: (Node) -> Bool) -> [Node] {
         return [nodeBy(predicate: predicate)].compactMap { $0 }
     }
 


### PR DESCRIPTION
### Intention
- Sometimes we want to search by some custom predicate. We may want to search by some id's prefix, regex, etc.

### Updates
- `func nodeBy(tag:)` is left, but added `func nodeBy(predicate:)` which is more customisable (see 'Intention' paragraph).