### PR TITLE
Added ability to handle touches in bigger touch area than node's bounds

### DIFF
--- a/Source/platform/iOS/Common_iOS.swift
+++ b/Source/platform/iOS/Common_iOS.swift
@@ -30,6 +30,7 @@ public typealias MPinchGestureRecognizer = UIPinchGestureRecognizer
 public typealias MRotationGestureRecognizer = UIRotationGestureRecognizer
 public typealias MScreen = UIScreen
 public typealias MViewContentMode = UIView.ContentMode
+public typealias MEdgeInsets = UIEdgeInsets
 
 func MDefaultRunLoopMode() -> RunLoop.Mode {
     return RunLoop.Mode.default

--- a/Source/platform/macOS/Common_macOS.swift
+++ b/Source/platform/macOS/Common_macOS.swift
@@ -29,6 +29,7 @@ public typealias MPanGestureRecognizer = NSPanGestureRecognizer
 public typealias MPinchGestureRecognizer = NSMagnificationGestureRecognizer
 public typealias MRotationGestureRecognizer = NSRotationGestureRecognizer
 public typealias MScreen = NSScreen
+public typealias MEdgeInsets = NSEdgeInsets
 
 func MDefaultRunLoopMode() -> RunLoop.Mode {
     return RunLoop.Mode.default
@@ -187,6 +188,24 @@ extension NSWindow {
 extension NSBezierPath {
     var mUsesEvenOddFillRule: Bool {
         return self.windingRule == .evenOdd
+    }
+}
+
+extension MEdgeInsets {
+    
+    static var zero: MEdgeInsets {
+        return MEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+}
+
+extension CGRect {
+    func inset(by contentInset: MEdgeInsets) -> CGRect {
+        return CGRect(
+            x: minX + contentInset.left,
+            y: minY + contentInset.top,
+            width: width - CGFloat(contentInset.horizontal),
+            height: height - CGFloat(contentInset.vertical)
+        )
     }
 }
 

--- a/Source/render/GroupRenderer.swift
+++ b/Source/render/GroupRenderer.swift
@@ -46,9 +46,9 @@ class GroupRenderer: NodeRenderer {
         }
     }
 
-    override func doFindNodeAt(path: NodePath, ctx: CGContext) -> NodePath? {
+    override func doFindNodeAt(path: NodePath, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
         for renderer in renderers.reversed() {
-            if let result = renderer.findNodeAt(parentNodePath: path, ctx: ctx) {
+            if let result = renderer.findNodeAt(parentNodePath: path, ctx: ctx, contentInset: contentInset) {
                 return result
             }
         }

--- a/Source/render/ImageRenderer.swift
+++ b/Source/render/ImageRenderer.swift
@@ -56,7 +56,7 @@ class ImageRenderer: NodeRenderer {
         }
     }
 
-    override func doFindNodeAt(path: NodePath, ctx: CGContext) -> NodePath? {
+    override func doFindNodeAt(path: NodePath, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
 
         if let mImage = MImage(named: image.src),
            let rect = BoundsUtils.getRect(of: image, mImage: mImage) {

--- a/Source/render/NodeRenderer.swift
+++ b/Source/render/NodeRenderer.swift
@@ -272,7 +272,7 @@ class NodeRenderer {
         fatalError("Unsupported")
     }
 
-    final func findNodeAt(location: CGPoint, ctx: CGContext) -> NodePath? {
+    final func findNodeAt(location: CGPoint, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
         guard node.opaque, let inverted = node.place.invert() else {
             return .none
         }
@@ -286,11 +286,11 @@ class NodeRenderer {
         applyClip(in: ctx)
         let loc = location.applying(inverted.toCG())
         let path = NodePath(node: node, location: loc)
-        let result = doFindNodeAt(path: path, ctx: ctx)
+        let result = doFindNodeAt(path: path, ctx: ctx, contentInset: contentInset)
         return result
     }
 
-    final func findNodeAt(parentNodePath: NodePath, ctx: CGContext) -> NodePath? {
+    final func findNodeAt(parentNodePath: NodePath, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
         guard node.opaque, let inverted = node.place.invert() else {
             return .none
         }
@@ -304,11 +304,11 @@ class NodeRenderer {
         applyClip(in: ctx)
         let loc = parentNodePath.location.applying(inverted.toCG())
         let path = NodePath(node: node, location: loc, parent: parentNodePath)
-        let result = doFindNodeAt(path: path, ctx: ctx)
+        let result = doFindNodeAt(path: path, ctx: ctx, contentInset: contentInset)
         return result
     }
 
-    public func doFindNodeAt(path: NodePath, ctx: CGContext) -> NodePath? {
+    public func doFindNodeAt(path: NodePath, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
         return nil
     }
 

--- a/Source/render/RenderUtils.swift
+++ b/Source/render/RenderUtils.swift
@@ -551,24 +551,26 @@ class RenderUtils {
         }
     }
 
-    internal class func setGeometry(_ locus: Locus, ctx: CGContext) {
+    internal class func setGeometry(_ locus: Locus, ctx: CGContext, contentInset: MEdgeInsets? = nil) {
+        let contentInset = contentInset ?? .zero
+        
         if let rect = locus as? Rect {
-            ctx.addRect(rect.toCG())
+            ctx.addRect(rect.toCG().inset(by: contentInset.inverted))
         } else if let round = locus as? RoundRect {
             let corners = CGSize(width: CGFloat(round.rx), height: CGFloat(round.ry))
-            let path = MBezierPath(roundedRect: round.rect.toCG(), byRoundingCorners:
-                                    MRectCorner.allCorners, cornerRadii: corners).cgPath
+            let path = MBezierPath(roundedRect: round.rect.toCG().inset(by: contentInset.inverted),
+                                   byRoundingCorners: MRectCorner.allCorners, cornerRadii: corners).cgPath
             ctx.addPath(path)
         } else if let circle = locus as? Circle {
             let cx = circle.cx
             let cy = circle.cy
-            let r = circle.r
+            let r = circle.r + max(contentInset.horizontal, contentInset.vertical)
             ctx.addEllipse(in: CGRect(x: cx - r, y: cy - r, width: r * 2, height: r * 2))
         } else if let ellipse = locus as? Ellipse {
             let cx = ellipse.cx
             let cy = ellipse.cy
-            let rx = ellipse.rx
-            let ry = ellipse.ry
+            let rx = ellipse.rx + contentInset.horizontal
+            let ry = ellipse.ry + contentInset.vertical
             ctx.addEllipse(in: CGRect(x: cx - rx, y: cy - ry, width: rx * 2, height: ry * 2))
         } else {
             ctx.addPath(locus.toCGPath())

--- a/Source/render/ShapeRenderer.swift
+++ b/Source/render/ShapeRenderer.swift
@@ -53,8 +53,8 @@ class ShapeRenderer: NodeRenderer {
         }
     }
 
-    override func doFindNodeAt(path: NodePath, ctx: CGContext) -> NodePath? {
-        RenderUtils.setGeometry(shape.form, ctx: ctx)
+    override func doFindNodeAt(path: NodePath, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
+        RenderUtils.setGeometry(shape.form, ctx: ctx, contentInset: contentInset)
         var drawingMode: CGPathDrawingMode?
         if let stroke = shape.stroke {
             RenderUtils.setStrokeAttributes(stroke, ctx: ctx)

--- a/Source/render/TextRenderer.swift
+++ b/Source/render/TextRenderer.swift
@@ -70,7 +70,7 @@ class TextRenderer: NodeRenderer {
         }
     }
 
-    override func doFindNodeAt(path: NodePath, ctx: CGContext) -> NodePath? {
+    override func doFindNodeAt(path: NodePath, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
         guard let contains = node.bounds?.toCG().contains(path.location) else {
             return .none
         }

--- a/Source/utils/CGMappings.swift
+++ b/Source/utils/CGMappings.swift
@@ -211,3 +211,18 @@ extension CGPath {
         self.apply(info: unsafeBody, function: callback)
     }
 }
+
+extension MEdgeInsets {
+    
+    var inverted: MEdgeInsets {
+        return MEdgeInsets(top: -top, left: -left, bottom: -bottom, right: -right)
+    }
+    
+    var horizontal: Double {
+        return Double(left + right)
+    }
+    
+    var vertical: Double {
+        return Double(top + bottom)
+    }
+}

--- a/Source/views/MacawView.swift
+++ b/Source/views/MacawView.swift
@@ -16,7 +16,12 @@ open class MacawView: MView, MGestureRecognizerDelegate {
     internal var drawingView = DrawingView()
 
     public lazy var zoom = MacawZoom(view: self)
-
+    
+    public var touchContentInset: MEdgeInsets {
+        get { return drawingView.touchContentInset }
+        set { drawingView.touchContentInset = newValue }
+    }
+    
     open var node: Node {
         get { return drawingView.node }
         set { drawingView.node = newValue }
@@ -282,7 +287,9 @@ internal class DrawingView: MView {
     var touchesMap = [MTouchEvent: [NodePath]]()
     var touchesOfNode = [Node: [MTouchEvent]]()
     var recognizersMap = [MGestureRecognizer: [Node]]()
-
+    
+    var touchContentInset: MEdgeInsets = .zero
+    
     var context: RenderContext!
     var renderer: NodeRenderer?
 
@@ -333,17 +340,17 @@ internal class DrawingView: MView {
         guard let ctx = context.cgContext else {
             return .none
         }
-        return doFindNode(location: location, ctx: ctx)?.node
+        return doFindNode(location: location, ctx: ctx, contentInset: nil)?.node
     }
 
-    private func doFindNode(location: CGPoint, ctx: CGContext) -> NodePath? {
+    private func doFindNode(location: CGPoint, ctx: CGContext, contentInset: MEdgeInsets?) -> NodePath? {
         guard let renderer = renderer else {
             return .none
         }
-        return renderer.findNodeAt(location: location, ctx: ctx)
+        return renderer.findNodeAt(location: location, ctx: ctx, contentInset: contentInset)
     }
 
-    private func doFindNode(location: CGPoint) -> NodePath? {
+    private func doFindNode(location: CGPoint, contentInset: MEdgeInsets?) -> NodePath? {
         MGraphicsBeginImageContextWithOptions(self.bounds.size, false, 1.0)
         defer {
             MGraphicsEndImageContext()
@@ -352,7 +359,7 @@ internal class DrawingView: MView {
             return .none
         }
         let loc = location.applying(inverted.toCG())
-        return doFindNode(location: loc, ctx: ctx)
+        return doFindNode(location: loc, ctx: ctx, contentInset: contentInset)
     }
 
     // MARK: - Touches
@@ -370,7 +377,7 @@ internal class DrawingView: MView {
 
         for touch in touchPoints {
             let location = CGPoint(x: touch.x, y: touch.y)
-            var nodePath = doFindNode(location: location)
+            var nodePath = doFindNode(location: location, contentInset: touchContentInset)
 
             if touchesMap[touch] == nil {
                 touchesMap[touch] = [NodePath]()
@@ -498,7 +505,7 @@ internal class DrawingView: MView {
         }
 
         let location = recognizer.location(in: self)
-        var nodePath = doFindNode(location: location)
+        var nodePath = doFindNode(location: location, contentInset: touchContentInset)
 
         while let current = nodePath {
             let node = current.node
@@ -522,7 +529,7 @@ internal class DrawingView: MView {
         }
 
         let location = recognizer.location(in: self)
-        guard var nodePath = doFindNode(location: location) else {
+        guard var nodePath = doFindNode(location: location, contentInset: touchContentInset) else {
             return
         }
 
@@ -549,7 +556,7 @@ internal class DrawingView: MView {
 
         if recognizer.state == .began {
             let location = recognizer.location(in: self)
-            guard var nodePath = doFindNode(location: location) else {
+            guard var nodePath = doFindNode(location: location, contentInset: touchContentInset) else {
                 return
             }
 
@@ -599,7 +606,7 @@ internal class DrawingView: MView {
 
         if recognizer.state == .began {
             let location = recognizer.location(in: self)
-            guard var nodePath = doFindNode(location: location) else {
+            guard var nodePath = doFindNode(location: location, contentInset: touchContentInset) else {
                 return
             }
 
@@ -642,7 +649,7 @@ internal class DrawingView: MView {
 
         if recognizer.state == .began {
             let location = recognizer.location(in: self)
-            guard var nodePath = doFindNode(location: location) else {
+            guard var nodePath = doFindNode(location: location, contentInset: touchContentInset) else {
                 return
             }
 


### PR DESCRIPTION
### Intention
- Sometimes we need to handle taps on relatively small shapes like small circles, etc. So it is needed to increase effective tap area for better UX.

### Updates
- Added `public var touchContentInset: MEdgeInsets` into `MacawView` that is passed to renderers to increase effective shape bounds inside `doFindNodeAt` method. 

P.S I know that it looks more like a workaround, so I'm not sure do you think it is a good idea to add this code into main repository. Please just let me know what do you think about it. If you think it is not a good idea, then I will close this PR.

Thanks in advance!