### PR TITLE
OS version availability checks to resolve deprecation warnings

### DIFF
--- a/Source/platform/iOS/MDisplayLink_iOS.swift
+++ b/Source/platform/iOS/MDisplayLink_iOS.swift
@@ -23,7 +23,11 @@ class MDisplayLink: MDisplayLinkProtocol {
         self.onUpdate = onUpdate
 
         displayLink = CADisplayLink(target: self, selector: #selector(updateHandler))
-        displayLink?.frameInterval = 1
+        if #available(iOS 10.0, *) {
+            displayLink?.preferredFramesPerSecond = 1
+        } else {
+            displayLink?.frameInterval = 1
+        }
         displayLink?.add(to: RunLoop.current, forMode: RunLoop.Mode.default)
     }
 

--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -705,7 +705,7 @@ open class SVGParser {
         }
         var rgbValue: UInt32 = 0
         if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), let scannedInt = Scanner(string: cleanedHexString).scanUInt64(representation: .hexadecimal) {
-                rgbValue = UInt32(scannedInt)
+            rgbValue = UInt32(scannedInt)
         } else {
             Scanner(string: cleanedHexString).scanHexInt32(&rgbValue)
         }

--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -704,10 +704,8 @@ open class SVGParser {
             cleanedHexString = "\(x[0])\(x[0])\(x[1])\(x[1])\(x[2])\(x[2])"
         }
         var rgbValue: UInt32 = 0
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            if let scannedInt = Scanner(string: cleanedHexString).scanUInt64(representation: .hexadecimal) {
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), let scannedInt = Scanner(string: cleanedHexString).scanUInt64(representation: .hexadecimal) {
                 rgbValue = UInt32(scannedInt)
-            }
         } else {
             Scanner(string: cleanedHexString).scanHexInt32(&rgbValue)
         }

--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -544,14 +544,14 @@ open class SVGParser {
 
         stopParse: while !scanner.isAtEnd {
             guard let attributeName = scanner.scannedCharacters(from: .transformationAttributeCharacters),
-                  scanner.scanString("(", into: nil),
+                  scanner.scannedString("(") != nil,
                   let valuesString = scanner.scannedUpToString(")"),
-                  scanner.scanString(")", into: nil) else {
+                  scanner.scannedString(")") != nil else {
                 break stopParse
             }
 
             // Skip an optional comma after ")".
-            _ = scanner.scanString(",", into: nil)
+            _ = scanner.scannedString(",")
 
             let values = parseTransformValues(valuesString)
             if values.isEmpty {
@@ -654,7 +654,7 @@ open class SVGParser {
             } else {
                 break
             }
-            _ = scanner.scanString(",", into: nil)
+            _ = scanner.scannedString(",")
         }
 
         return collectedValues
@@ -704,7 +704,13 @@ open class SVGParser {
             cleanedHexString = "\(x[0])\(x[0])\(x[1])\(x[1])\(x[2])\(x[2])"
         }
         var rgbValue: UInt32 = 0
-        Scanner(string: cleanedHexString).scanHexInt32(&rgbValue)
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            if let scannedInt = Scanner(string: cleanedHexString).scanUInt64(representation: .hexadecimal) {
+                rgbValue = UInt32(scannedInt)
+            }
+        } else {
+            Scanner(string: cleanedHexString).scanHexInt32(&rgbValue)
+        }
 
         let red = CGFloat((rgbValue >> 16) & 0xff)
         let green = CGFloat((rgbValue >> 08) & 0xff)
@@ -994,11 +1000,10 @@ open class SVGParser {
 
         let scanner = Scanner(string: pointsString)
         while !scanner.isAtEnd {
-            var resultPoint: Double = 0
-            if scanner.scanDouble(&resultPoint) {
+            if let resultPoint = scanner.scannedDouble() {
                 resultPoints.append(resultPoint)
             }
-            _ = scanner.scanCharacters(from: [","], into: nil)
+            _ = scanner.scannedString(",")
         }
 
         if resultPoints.count % 2 == 1 {
@@ -2194,6 +2199,16 @@ fileprivate extension Scanner {
         } else {
             var string: NSString?
             return scanUpTo(substring, into: &string) ? string as String? : nil
+        }
+    }
+    
+    /// A version of `scanString(_:)`, available for an earlier OS.
+    func scannedString(_ searchString: String) -> String? {
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            return scanString(searchString)
+        } else {
+            var string: NSString?
+            return scanString(searchString, into: &string) ? string as String? : nil
         }
     }
 }


### PR DESCRIPTION
Mainly deprecations in `Scanner` methods from iOS 13.0 and one from `CADisplayLink`. See image here for warnings when we've included via cocoapods
<img width="254" alt="image" src="https://user-images.githubusercontent.com/1321276/96103364-32b8e600-0f0a-11eb-9ab1-141178b3442f.png">
