### PR TITLE
Dispose renderer when DrawingView is deinit.

### DIFF
--- a/Source/views/MacawView.swift
+++ b/Source/views/MacawView.swift
@@ -671,6 +671,12 @@ internal class DrawingView: MView {
             recognizersMap.removeValue(forKey: recognizer)
         }
     }
+    
+    // MARK: - Cleanup
+    
+    deinit {
+        renderer?.dispose()
+    }
 }
 
 class LayoutHelper {


### PR DESCRIPTION
We saw that a lot of memory is leaked when creating `SVGView` this way:
`SVGView(node: try! SVGParser.parse(text: path), frame: CGRect())`

I did some debugging and I think I found the issue. 
`DrawingView` is not disposing its renderer when it's deinit and so it's leaked. This PR fixes that.

Another way this leaks could be solved (and probably should be to avoid future leaks) is to make `animationObservers` on a `Node` a weak array so that it doesn't retain its observers.
It's a little bit of extra work but maybe someone will find some time to implement it. 

Cheers.

