### PR TITLE
Added version check in the SWXMLHash, because it has some major chang…

### DIFF
--- a/Macaw.podspec
+++ b/Macaw.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
      'Source/**/*.swift'
   ]
 
-  s.dependency 'SWXMLHash'
+  s.dependency 'SWXMLHash' , '5.0.2'
 end


### PR DESCRIPTION
…es. Macaw is not able to compile itself with the new dependency