### PR TITLE
#686 Renderer dispose added - it is still needed

### DIFF
--- a/Source/utils/CGMappings.swift
+++ b/Source/utils/CGMappings.swift
@@ -149,6 +149,7 @@ public extension Node {
         
         defer {
             MGraphicsEndImageContext()
+            renderer.dispose()
         }
 
         guard let img = MGraphicsGetImageFromCurrentImageContext() else {


### PR DESCRIPTION
add missed `renderer.dispose()` call