### PR TITLE
Native Image Scale

### DIFF
--- a/Macaw.podspec
+++ b/Macaw.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Macaw"
-  s.version          = "0.9.9"
+  s.version          = "0.9.10"
   s.summary          = "Powerful and easy-to-use vector graphics library with SVG support written in Swift."
 
   s.homepage         = 'https://github.com/exyte/Macaw.git'

--- a/Source/utils/CGMappings.swift
+++ b/Source/utils/CGMappings.swift
@@ -149,6 +149,7 @@ public extension Node {
         
         defer {
             MGraphicsEndImageContext()
+            renderer.dispose()
         }
 
         guard let img = MGraphicsGetImageFromCurrentImageContext() else {

--- a/Source/utils/CGMappings.swift
+++ b/Source/utils/CGMappings.swift
@@ -135,11 +135,11 @@ public extension CGAffineTransform {
 
 public extension Node {
 
-    func toNativeImage(size: Size, layout: ContentLayout = .of()) throws -> MImage {
+    func toNativeImage(size: Size, layout: ContentLayout = .of(), scale: CGFloat = 0.0) throws -> MImage {
         let renderer = RenderUtils.createNodeRenderer(self, view: nil)
         let rect = size.rect()
 
-        MGraphicsBeginImageContextWithOptions(size.toCG(), false, 1)
+        MGraphicsBeginImageContextWithOptions(size.toCG(), false, scale)
         let ctx = MGraphicsGetCurrentContext()!
         ctx.clear(rect.toCG())
 


### PR DESCRIPTION
`toNativeImage()` creates a blurry image on Retina devices.

According to the [reference](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho)
`The scale factor to apply to the bitmap. If you specify a value of 0.0, the scale factor is set to the scale factor of the device’s main screen. `

Adressing issues #752, #686 and PRs #780, #748
