### PR TITLE
Fix #766 SVGParser will parse the `class` attribute as Node Tag.

### DIFF
--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -897,8 +897,15 @@ open class SVGParser {
     }
 
     fileprivate func getTag(_ element: XMLHash.XMLElement) -> [String] {
-        let id = element.allAttributes["id"]?.text
-        return id.map { [$0] } ?? []
+        var result: [String] = []
+        if let id = element.allAttributes["id"]?.text {
+            result.append(id)
+        }
+        if let classes = element.allAttributes["class"]?.text.split(separator: " ").map({ String($0) }) {
+            result.append(contentsOf: classes)
+        }
+        
+        return Array(Set(result))
     }
 
     fileprivate func getOpacity(_ styleParts: [String: String]) -> Double {


### PR DESCRIPTION
I use Macaw for SVG rendering.

I have the same problem as #766

I need to dynamically modify the style by `class`. But there is no way to get nodes by `class`.

SVGParser currently only parses `id` as a Node Tag. This Pull Request parses `class` as a Node Tag as well.

This way, the node of the specified class can be found by the `node.nodesBy(tag:)` method without breaking the original design.