### PR TITLE
Unnecessary black color has been fixed.

### DIFF
--- a/Source/svg/SVGParser.swift
+++ b/Source/svg/SVGParser.swift
@@ -751,7 +751,7 @@ open class SVGParser {
         }
 
         guard var fillColor = styleParts[SVGKeys.fill] else {
-            return Color.black.with(a: opacity)
+            return Color.clear
         }
         if let colorId = parseIdFromUrl(fillColor) {
             if let fill = defFills[colorId] {


### PR DESCRIPTION
There is a problem on iOS when we have Shape with Stroke and NO Fill tag in XML. Color by Default is black but I think that clear color is more useful and standard (cause I compare SVG with online viewer and there is no black color by default).